### PR TITLE
 main: Present application window

### DIFF
--- a/assets/resources/window.blp
+++ b/assets/resources/window.blp
@@ -5,7 +5,6 @@ Adw.Window main_window {
     default-width: 360;
     default-height: 380;
     title: _("Sessions");
-    visible: true;
 
     content: Adw.ToolbarView toolbar_view {
       [top]

--- a/main.go
+++ b/main.go
@@ -363,6 +363,7 @@ func main() {
 		updateDial()
 
 		a.AddWindow(&w.Window)
+		w.Present()
 	})
 
 	if code := a.Run(os.Args); code > 0 {


### PR DESCRIPTION
Marking it as `visible` before adding it to the `AdwApplication` has the negative side effect that things like `app_id` will be inferred from defaults rather than from the application object.

This fixes e.g. the missing icon on phosh as the app-id is now correct:
    
```console
$ WAYLAND_DEBUG=1 flatpak run  com.pojtinger.felicitas.Sessions |& grep -i "xdg.*set_app_id"
[1660879.185]  -> xdg_toplevel#64.set_app_id("com.pojtinger.felicitas.Sessions")
```
    
Closes: #6
Signed-off-by: Guido Günther <agx@sigxcpu.org>