### PR TITLE
feat: Use `error_code` in Dial's snapshot

### DIFF
--- a/internal/components/dial.go
+++ b/internal/components/dial.go
@@ -99,7 +99,7 @@ func init() {
 			styleContext := widget.GetStyleContext()
 			var accent, errColor gdk.RGBA
 			styleContext.LookupColor("accent_bg_color", &accent)
-			styleContext.LookupColor("error_bg_color", &errColor)
+			styleContext.LookupColor("error_color", &errColor)
 
 			highContrast := dialW.app.GetStyleManager().GetHighContrast()
 


### PR DESCRIPTION
After seeing the screenshots on fedi, `error-bg-color` felt a little bit too dark in dark mode and might look better if it matched the stop button's style like the Mac app does

| before | after |
| --- | --- |
| <img width="410" height="448" alt="Screenshot From 2026-04-23 18-11-24" src="https://github.com/user-attachments/assets/8762c9ac-0863-4c18-914d-f2690efe49f1" /> | <img width="410" height="448" alt="Screenshot From 2026-04-23 16-50-01" src="https://github.com/user-attachments/assets/22a6a7de-7163-41de-ab6c-54fab5faccf2" /> |
| <img width="410" height="448" alt="Screenshot From 2026-04-23 18-11-54" src="https://github.com/user-attachments/assets/8b0e9118-7ddd-458b-b4da-0b9e04212106" /> | <img width="410" height="448" alt="image" src="https://github.com/user-attachments/assets/6f0171bd-b512-4780-8013-792fa5227149" /> |

Also, as you can see above, the after one is darker now, not sure if it helps differentiate it more with the red accent color when paused:

| red accent running before | red accent paused | red accent running after |
| --- | --- | --- |
| <img width="410" height="448" alt="Screenshot From 2026-04-23 18-11-54" src="https://github.com/user-attachments/assets/8b0e9118-7ddd-458b-b4da-0b9e04212106" /> | <img width="410" height="448" alt="image" src="https://github.com/user-attachments/assets/09a347cf-befa-4793-9a11-5481c80d0fd3" /> | <img width="410" height="448" alt="image" src="https://github.com/user-attachments/assets/6f0171bd-b512-4780-8013-792fa5227149" /> |

what do you think?